### PR TITLE
feat: AI API JSON 반환 구현 및 테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation ("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -35,6 +36,12 @@ dependencies {
     //NAVER CLOVA
     implementation ("org.springframework.boot:spring-boot-starter-webflux")
     implementation ("com.fasterxml.jackson.core:jackson-databind")
+
+    //lombok
+    compileOnly("org.projectlombok:lombok:1.18.26")
+    annotationProcessor("org.projectlombok:lombok:1.18.26")
+    testCompileOnly("org.projectlombok:lombok:1.18.26")
+    testAnnotationProcessor("org.projectlombok:lombok:1.18.26")
 
 }
 

--- a/src/main/java/com/swyp10/pinggyewang/config/ClovaStudioConfig.java
+++ b/src/main/java/com/swyp10/pinggyewang/config/ClovaStudioConfig.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.UUID;
+
 @Configuration
 public class ClovaStudioConfig {
 
@@ -16,16 +18,15 @@ public class ClovaStudioConfig {
     @Value("${clova.api.key}")
     private String apiKey;
 
-    @Value("${clova.api.request-id}")
-    private String requestId;
-
     @Bean
     public WebClient clovaWebClient() {
+
         return WebClient.builder()
                 .baseUrl(apiUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                .defaultHeader("X-NCP-CLOVASTUDIO-REQUEST-ID", requestId)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("X-NCP-CLOVASTUDIO-REQUEST-ID", UUID.randomUUID().toString())
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .build();
 
     }

--- a/src/main/java/com/swyp10/pinggyewang/config/JsonConfig.java
+++ b/src/main/java/com/swyp10/pinggyewang/config/JsonConfig.java
@@ -1,0 +1,18 @@
+package com.swyp10.pinggyewang.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}

--- a/src/main/java/com/swyp10/pinggyewang/controller/ClovaController.java
+++ b/src/main/java/com/swyp10/pinggyewang/controller/ClovaController.java
@@ -1,14 +1,12 @@
 package com.swyp10.pinggyewang.controller;
 
+import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
+import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
 import com.swyp10.pinggyewang.service.ClovaService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Mono;
-
-import java.util.Map;
 
 @RestController
 public class ClovaController {
@@ -20,11 +18,9 @@ public class ClovaController {
     }
 
     @PostMapping("/api/clova/generate")
-    public Mono<ResponseEntity<Map<String,String>>> textGenerate(
-            @RequestBody Map<String, String> request) {
-        String prompt = request.get("prompt");
-        return clovaService.generateSentence(prompt)
-                .map(text -> ResponseEntity.ok(Map.of("result", text)))
-                .defaultIfEmpty(ResponseEntity.status(HttpStatus.NO_CONTENT).build());
+    public ResponseEntity<ExcuseResponse> textGenerate(
+            @RequestBody ExcuseRequest request) {
+        ExcuseResponse response = clovaService.generateSentence(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/swyp10/pinggyewang/dto/request/ExcuseRequest.java
+++ b/src/main/java/com/swyp10/pinggyewang/dto/request/ExcuseRequest.java
@@ -1,0 +1,32 @@
+package com.swyp10.pinggyewang.dto.request;
+
+public class ExcuseRequest {
+
+    private String situation;
+    private String target;
+    private String tone;
+
+    public void setSituation(String situation) {
+        this.situation = situation;
+    }
+
+    public String getSituation(){
+        return situation;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTone(String tone) {
+        this.tone = tone;
+    }
+
+    public String getTone() {
+        return tone;
+    }
+}

--- a/src/main/java/com/swyp10/pinggyewang/dto/response/ExcuseResponse.java
+++ b/src/main/java/com/swyp10/pinggyewang/dto/response/ExcuseResponse.java
@@ -1,0 +1,46 @@
+package com.swyp10.pinggyewang.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+
+@Getter
+@Setter
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExcuseResponse {
+    private String situation;
+
+    private String target;
+
+    private String tone;
+
+    private String excuse;
+
+    private String credibilityWhy;
+
+    private Double credibilityScore;
+
+    private String category;
+
+    private List<String> keyword;
+
+    private List<String> alts;
+
+    @JsonProperty("tokens_used")
+    private Integer tokensUsed;
+
+    @JsonProperty("response_time_ms")
+    private Long responseTimeMs;
+
+    @JsonProperty("created_at")
+    private OffsetDateTime createdAt;
+
+
+}

--- a/src/main/java/com/swyp10/pinggyewang/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/swyp10/pinggyewang/security/config/WebSecurityConfig.java
@@ -43,6 +43,7 @@ public class WebSecurityConfig {
             auth
                 .requestMatchers("/").permitAll()
                 .requestMatchers("/auth/login").permitAll()
+                .requestMatchers("/api/clova/*").permitAll()
                 .requestMatchers("/h2-console/**").permitAll()
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/favicon.ico").permitAll()

--- a/src/main/java/com/swyp10/pinggyewang/service/ClovaService.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/ClovaService.java
@@ -1,9 +1,13 @@
 package com.swyp10.pinggyewang.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
+import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
@@ -11,29 +15,62 @@ import java.util.Map;
 @Service
 public class ClovaService {
     private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    private final String systemPrompt;
 
-    public ClovaService(WebClient webClient){
+    public ClovaService(WebClient webClient, ObjectMapper objectMapper, @Value("${clova.system-prompt}") String systemPrompt){
         this.webClient = webClient;
+        this.objectMapper = objectMapper;
+        this.systemPrompt = systemPrompt;
     }
 
-    public Mono<String> generateSentence(String userPrompt) {
+    public ExcuseResponse generateSentence(ExcuseRequest req) {
 
-        Map<String, Object> body = Map.of(
-                "model", "HCX-005",
-                "messages", List.of(
-                        Map.of("role", "user", "content", userPrompt)
-                ),
-                "maxTokens", 512,
-                "temperature", 0.7
-        );
+        try {
+            String userJson = objectMapper.writeValueAsString(req);
 
-        return webClient.post()
-                .bodyValue(body)
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .map(json ->
-                        json.at("/choices/0/message/content").asText()
-                );
+            List<Map<String,String>> messages = List.of(
+                Map.of("role", "system", "content", systemPrompt),
+                Map.of("role", "user", "content", userJson)
+            );
+
+            Map<String, Object> body = Map.of(
+                    "model", "HCX-005",
+                    "messages", messages,
+                    "maxTokens", 512,
+                    "temperature", 0.7
+            );
+
+            String response = webClient.post()
+                    .accept(MediaType.APPLICATION_JSON)
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            if (response == null || response.isBlank()) {
+                throw new RuntimeException("클로바 API가 빈 응답을 반환했습니다.");
+            }
+
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode contentNode = root.at("/result/message/content");
+            if (contentNode.isMissingNode()) {
+                throw new RuntimeException("content 필드를 찾을 수 없습니다: " + root);
+            }
+            String content = contentNode.asText()
+                    .replaceFirst("(?m)^```json\\s*\\n?", "")
+                    .replaceFirst("(?m)\\n?```$", "")
+                    .trim();
+
+            System.out.println("===== Final JSON to parse =====");
+            System.out.println(content);
+
+
+            return objectMapper.readValue(content, ExcuseResponse.class);
+
+        } catch (Exception e){
+            throw  new RuntimeException("AI 호출 또는 파싱 실패", e);
+        }
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,24 @@ jwt:
 
 clova:
   api:
-    url: https://{region}.clovastudio.api.ncloud.com/v1/chat/completions # 발급 후 region 값 입력 예정
-    key: YOUR_API_KEY # 발급 후 입력 예정
-    request-id: YOUR_REQUEST_ID # 발급 후 입력 예정
+    url: https://clovastudio.stream.ntruss.com/testapp/v3/chat-completions/HCX-005
+    key: nv-d6eadc1a642f46d2834ffdb0c1e11e07flHE # test api key
+  system-prompt: |-
+    당신은 “핑계 생성기” AI입니다.
+    JSON 입력으로 "situation", "target", "tone" 키가 주어지면, 반드시 아래 정확한 스키마에 따라 JSON으로만 응답해야 합니다.
+    
+    {
+      "situation": string,
+      "target": string,
+      "tone": string,
+      "excuse": string,
+      "credibilityWhy": string,
+      "credibilityScore" : number,
+      "category": string,
+      "keyword": [string],
+      "alts": [string],
+      "tokens_used": number,
+      "response_time_ms": number,
+      "created_at": string
+    }
 

--- a/src/test/java/com/swyp10/pinggyewang/ClovaIntegrationTest.java
+++ b/src/test/java/com/swyp10/pinggyewang/ClovaIntegrationTest.java
@@ -1,0 +1,37 @@
+package com.swyp10.pinggyewang;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
+import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
+import com.swyp10.pinggyewang.service.ClovaService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ClovaIntegrationTest {
+
+    @Autowired
+    private ClovaService clovaService;
+
+    @Test
+    void printApiRequestLog() throws JsonProcessingException {
+        ExcuseRequest req = new ExcuseRequest();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        req.setSituation("회의에 늦음");
+        req.setTarget("팀장님");
+        req.setTone("정중하게");
+
+        ExcuseResponse resp = clovaService.generateSentence(req);
+
+        System.out.println("====== AI 응답 ======");
+        System.out.println(resp);
+
+        assert resp.getExcuse() != null;
+        assert resp.getCategory() != null;
+        assert resp.getCreatedAt() != null;
+    }
+}


### PR DESCRIPTION
1. 개요
- 서비스 : 상황(situation), 대상(target), 톤(tone)을 입력받아 AI(Clova HCX-005)로부터 JSON 포맷의 핑계(excuse) 응답 생성

2. 변경사항
- 입력 모델링(DTO 생성)
- JSON 응답 파싱 및 DTO 매핑
- 테스트 검증

3. Request/Response 구조
- 요청
{
  "situation": "회사에 지각",
  "target":    "직장 상사",
  "tone":      "정중하게"
}
- 응답
{
  "situation": "회의에 늦음",
  "target": "팀장님",
  "tone": "정중하게",
  "excuse": "정말 죄송합니다. 오늘 아침에 갑작스러운 교통 체증 때문에 예상보다 늦게 도착했습니다.",
  "credibilityWhy": "교통 문제는 예측하기 어려운 상황이므로 팀장님께서 이해해주실 가능성이 높습니다.",
  "credibilityScore": 7,
  "category": "교통 문제",
  "keyword": ["교통 체증", "예측 불가능"],
  "alts": ["도로 공사로 인해 지연", "대중교통 연착"],
  "tokens_used": 6,
  "response_time_ms": 500,
  "created_at": "2023-03-29T10:15:00Z"
} 

4. Jackson 설정
- com.fasterxml.jackson.datatype:jackson-datatype-jsr310 의존성 추가

5. Lombok 설정
- compileOnly("org.projectlombok:lombok") + annotationProcessor("lombok") / testCompileOnly + testAnnotationProcessor 구성
- DTO에 @Getter, @Setter, @ToString 추가
- Settings > Enable anotation proccesing 활성화

6. 테스트
- ClovaIntegrationTes.java run

7. 추가 확인 사항

- [ ] lombok 없이 getter, setter, toString 정의 다시 확인 필요
- [ ] alts 반환값 자세한 버전 필요한지 확인
- [ ] created_at 타입 OffsetDateTime -> db 데이터 생성시 문제 없는지 확인
- [ ] keyword 해시태그로 사용법 고려