### PR TITLE
feat: 미니 대시보드 데이터 조회 기능 추가, Excuse DB 테이블 컬럼 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,8 +44,6 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.26")
     testCompileOnly("org.projectlombok:lombok:1.18.26")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.26")
-
-
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/swyp10/pinggyewang/controller/ClovaController.java
+++ b/src/main/java/com/swyp10/pinggyewang/controller/ClovaController.java
@@ -11,16 +11,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ClovaController {
 
-    private final ExcuseGenerator excuseGenerator;
+  private final ExcuseGenerator excuseGenerator;
 
-    public ClovaController(ExcuseGenerator excuseGenerator){
-        this.excuseGenerator = excuseGenerator;
-    }
+  public ClovaController(ExcuseGenerator excuseGenerator) {
+    this.excuseGenerator = excuseGenerator;
+  }
 
-    @PostMapping("/api/clova/generate")
-    public ResponseEntity<ExcuseResponse> textGenerate(
-            @RequestBody ExcuseRequest request) {
-        ExcuseResponse response = excuseGenerator.generateSentence(request);
-        return ResponseEntity.ok(response);
-    }
+  @PostMapping("/api/clova/generate")
+  public ResponseEntity<ExcuseResponse> textGenerate(@RequestBody ExcuseRequest request) {
+    ExcuseResponse response = excuseGenerator.generateSentence(request);
+    return ResponseEntity.ok(response);
+  }
 }

--- a/src/main/java/com/swyp10/pinggyewang/controller/DashboardController.java
+++ b/src/main/java/com/swyp10/pinggyewang/controller/DashboardController.java
@@ -1,20 +1,13 @@
 package com.swyp10.pinggyewang.controller;
 
+import com.swyp10.pinggyewang.dto.response.ExcuseStatisticsResponse;
 import com.swyp10.pinggyewang.service.ExcuseService;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-@Controller
-@RequestMapping("/admin")
+@RestController
+@RequestMapping("/api/dashboard")
 public class DashboardController {
 
   private final ExcuseService excuseService;
@@ -23,73 +16,8 @@ public class DashboardController {
     this.excuseService = excuseService;
   }
 
-  @GetMapping("/dashboard")
-  public String dashboard(Model model) {
-    // 가짜 통계 데이터 생성
-    Map<String, Object> stats = excuseService.getDashboardStats();
-
-    model.addAttribute("stats", stats);
-
-    // 최근 변명 데이터 (가짜 데이터)
-    List<Map<String, Object>> recentExcuses = Arrays.asList(
-        createExcuseData(1, "죄송합니다. 예상치 못한 교통체증으로 인해 늦었습니다.", "회의 지각", "상사", "Work", 7.5),
-        createExcuseData(2, "노트북이 갑자기 꺼져서 작업한 내용을 잃어버렸습니다.", "과제 마감일 놓침", "교수", "School", 6.8),
-        createExcuseData(3, "반려동물이 갑자기 아파서 병원에 데려가야 했습니다.", "약속 취소", "친구", "Personal", 9.2)
-    );
-
-    model.addAttribute("recentExcuses", recentExcuses);
-
-    // 카테고리 목록
-    List<String> categories = Arrays.asList("Work", "School", "Personal", "Social", "Health");
-    model.addAttribute("categories", categories);
-
-    // 차트 데이터
-    List<Map<String, Object>> dailyUsageData = Arrays.asList(
-        createDailyData("01-08", 187),
-        createDailyData("01-09", 234),
-        createDailyData("01-10", 312),
-        createDailyData("01-11", 278),
-        createDailyData("01-12", 298),
-        createDailyData("01-13", 345),
-        createDailyData("01-14", 234)
-    );
-    model.addAttribute("dailyUsageData", dailyUsageData);
-
-    List<Map<String, Object>> categoryData = Arrays.asList(
-        createCategoryData("Work", 4521),
-        createCategoryData("School", 3892),
-        createCategoryData("Personal", 2847),
-        createCategoryData("Social", 2156),
-        createCategoryData("Health", 1847)
-    );
-    model.addAttribute("categoryData", categoryData);
-
-    return "dashboard";
-  }
-
-  private Map<String, Object> createExcuseData(int id, String excuse, String situation, String target, String category, double credibilityScore) {
-    Map<String, Object> data = new HashMap<>();
-    data.put("id", id);
-    data.put("excuse", excuse);
-    data.put("situation", situation);
-    data.put("target", target);
-    data.put("category", category);
-    data.put("credibilityScore", credibilityScore);
-    data.put("createdAt", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-    return data;
-  }
-
-  private Map<String, Object> createDailyData(String date, int excuses) {
-    Map<String, Object> data = new HashMap<>();
-    data.put("date", date);
-    data.put("excuses", excuses);
-    return data;
-  }
-
-  private Map<String, Object> createCategoryData(String name, int value) {
-    Map<String, Object> data = new HashMap<>();
-    data.put("name", name);
-    data.put("value", value);
-    return data;
+  @GetMapping
+  public ExcuseStatisticsResponse dashboard() {
+    return excuseService.getStatistics();
   }
 }

--- a/src/main/java/com/swyp10/pinggyewang/domain/Excuse.java
+++ b/src/main/java/com/swyp10/pinggyewang/domain/Excuse.java
@@ -1,6 +1,7 @@
 package com.swyp10.pinggyewang.domain;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -51,22 +52,22 @@ public class Excuse {
   @Column(name = "response_time_ms")
   private Long responseTimeMs;
 
-  @Column(name = "ai_created_at")
-  private OffsetDateTime aiCreatedAt;
+  @Column(name = "is_regenerated", columnDefinition = "TINYINT(1)")
+  private Boolean isRegenerated;
 
   @CreationTimestamp
   @Column(name = "created_at", nullable = false, updatable = false)
-  private OffsetDateTime createdAt;
+  private LocalDateTime createdAt;
 
   @UpdateTimestamp
   @Column(name = "updated_at")
-  private OffsetDateTime updatedAt;
+  private LocalDateTime updatedAt;
 
   @Builder
   public Excuse(String situation, String target, String tone, String excuse,
       String credibilityWhy, Double credibilityScore, String category,
       String keywords, String alternatives, Integer tokensUsed,
-      Long responseTimeMs, OffsetDateTime aiCreatedAt) {
+      Long responseTimeMs, Boolean isRegenerated) {
     this.situation = situation;
     this.target = target;
     this.tone = tone;
@@ -78,7 +79,7 @@ public class Excuse {
     this.alternatives = alternatives;
     this.tokensUsed = tokensUsed;
     this.responseTimeMs = responseTimeMs;
-    this.aiCreatedAt = aiCreatedAt;
+    this.isRegenerated = isRegenerated;
   }
 
   public Long getId() {
@@ -129,15 +130,15 @@ public class Excuse {
     return responseTimeMs;
   }
 
-  public OffsetDateTime getAiCreatedAt() {
-    return aiCreatedAt;
-  }
-
-  public OffsetDateTime getCreatedAt() {
+  public LocalDateTime getCreatedAt() {
     return createdAt;
   }
 
-  public OffsetDateTime getUpdatedAt() {
+  public LocalDateTime getUpdatedAt() {
     return updatedAt;
+  }
+
+  public Boolean getIsRegenerated() {
+    return isRegenerated;
   }
 }

--- a/src/main/java/com/swyp10/pinggyewang/dto/request/ExcuseRequest.java
+++ b/src/main/java/com/swyp10/pinggyewang/dto/request/ExcuseRequest.java
@@ -1,4 +1,7 @@
 package com.swyp10.pinggyewang.dto.request;
 
-public record ExcuseRequest(String situation, String target, String tone) {
+public record ExcuseRequest(
+    String situation, String target, String tone, boolean isRegenerated
+) {
+
 }

--- a/src/main/java/com/swyp10/pinggyewang/dto/response/ExcuseResponse.java
+++ b/src/main/java/com/swyp10/pinggyewang/dto/response/ExcuseResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swyp10.pinggyewang.domain.Excuse;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -29,9 +30,9 @@ public record ExcuseResponse(
     Long responseTimeMs,
 
     @JsonProperty("created_at")
-    OffsetDateTime createdAt
+    LocalDateTime createdAt
 ) {
-    public Excuse toDomain() {
+    public Excuse toExcuse(final boolean isRegenerated) {
         return Excuse.builder()
             .situation(this.situation)
             .target(this.target)
@@ -44,7 +45,7 @@ public record ExcuseResponse(
             .alternatives(listToJson(this.alts))
             .tokensUsed(this.tokensUsed)
             .responseTimeMs(this.responseTimeMs)
-            .aiCreatedAt(this.createdAt)
+            .isRegenerated(isRegenerated)
             .build();
     }
 
@@ -61,7 +62,7 @@ public record ExcuseResponse(
             jsonToList(excuse.getAlternatives()),
             excuse.getTokensUsed(),
             excuse.getResponseTimeMs(),
-            excuse.getAiCreatedAt()
+            excuse.getCreatedAt()
         );
     }
 

--- a/src/main/java/com/swyp10/pinggyewang/dto/response/ExcuseStatisticsResponse.java
+++ b/src/main/java/com/swyp10/pinggyewang/dto/response/ExcuseStatisticsResponse.java
@@ -1,0 +1,8 @@
+package com.swyp10.pinggyewang.dto.response;
+
+public record ExcuseStatisticsResponse(
+    Long totalExcuses,
+    Double averageSatisfaction,
+    Double regenerationRate,
+    PeakTimeResponse peakTime
+) {}

--- a/src/main/java/com/swyp10/pinggyewang/dto/response/PeakTimeResponse.java
+++ b/src/main/java/com/swyp10/pinggyewang/dto/response/PeakTimeResponse.java
@@ -1,0 +1,4 @@
+package com.swyp10.pinggyewang.dto.response;
+
+public record PeakTimeResponse(Integer hour, Long count) {
+}

--- a/src/main/java/com/swyp10/pinggyewang/repository/ExcuseRepository.java
+++ b/src/main/java/com/swyp10/pinggyewang/repository/ExcuseRepository.java
@@ -1,12 +1,10 @@
 package com.swyp10.pinggyewang.repository;
 
 import com.swyp10.pinggyewang.domain.Excuse;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,15 +12,17 @@ public interface ExcuseRepository extends JpaRepository<Excuse, Long> {
 
   Long countByCreatedAtBetween(OffsetDateTime startDate, OffsetDateTime endDate);
 
-  @Query(value = """
-    SELECT 
-        COUNT(*) as total_excuses,
-        COUNT(CASE WHEN DATE(created_at) = CURDATE() THEN 1 END) as today_excuses,
-        COALESCE(ROUND(AVG(credibility_score), 1), 0) as avg_credibility_score,
-        COALESCE(ROUND(AVG(response_time_ms)), 0) as avg_response_time,
-        COALESCE(SUM(tokens_used), 0) as total_tokens_used,
-        COUNT(DISTINCT CASE WHEN created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY) THEN situation END) as active_users
-    FROM excuses
-    """, nativeQuery = true)
-  List<Object[]> findDashboardStats();
+  @Query("SELECT " +
+      "COUNT(e) as totalCount, " +
+      "AVG(COALESCE(e.credibilityScore, 0)) as avgSatisfaction, " +
+      "SUM(CASE WHEN e.isRegenerated = true THEN 1 ELSE 0 END) as regeneratedCount " +
+      "FROM Excuse e")
+  List<Object[]> getBasicStatistics(); // Object[] -> List<Object[]>로 변경
+
+  @Query("SELECT HOUR(e.createdAt) as hour, COUNT(e) as count " +
+      "FROM Excuse e " +
+      "GROUP BY HOUR(e.createdAt) " +
+      "ORDER BY count DESC " +
+      "LIMIT 1")
+  List<Object[]> getPeakTimeStatistics(); // Object[] -> List<Object[]>로 변경
 }

--- a/src/main/java/com/swyp10/pinggyewang/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/swyp10/pinggyewang/security/config/WebSecurityConfig.java
@@ -43,7 +43,7 @@ public class WebSecurityConfig {
             auth
                 .requestMatchers("/").permitAll()
                 .requestMatchers("/auth/login").permitAll()
-                .requestMatchers("/api/clova/*").permitAll()
+                .requestMatchers("/api/clova/**").permitAll()
                 .requestMatchers("/h2-console/**").permitAll()
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/favicon.ico").permitAll()
@@ -51,6 +51,7 @@ public class WebSecurityConfig {
                 .requestMatchers("/api/excuses/**").permitAll()
                 .requestMatchers("/health", "/actuator/health").permitAll()
                 .requestMatchers("/admin/**").permitAll()
+                .requestMatchers("/api/dashboard").permitAll()
                 .anyRequest().authenticated()
         )
         .headers(headers -> headers

--- a/src/main/java/com/swyp10/pinggyewang/service/ClovaService.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/ClovaService.java
@@ -12,7 +12,6 @@ import java.time.Duration;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -49,14 +48,14 @@ public class ClovaService implements ExcuseGenerator {
   }
 
   @Override
-  public ExcuseResponse generateSentence(ExcuseRequest request) {
+  public ExcuseResponse generateSentence(final ExcuseRequest request) {
     try {
       String requestBody = buildRequestBody(request);
       String apiResponse = callClovaApi(requestBody);
       String extractedContent = extractContentFromResponse(apiResponse);
       ExcuseResponse response = parseExcuseResponse(extractedContent);
 
-      excuseRepository.save(response.toDomain());
+      excuseRepository.save(response.toExcuse(request.isRegenerated()));
 
       return response;
     } catch (Exception e) {

--- a/src/main/java/com/swyp10/pinggyewang/service/mock/MockExcuseGenerator.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/mock/MockExcuseGenerator.java
@@ -2,6 +2,7 @@ package com.swyp10.pinggyewang.service.mock;
 
 import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
 import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -25,7 +26,7 @@ public class MockExcuseGenerator {
         ),  // alts
         10,  // tokensUsed
         300L,  // responseTimeMs
-        OffsetDateTime.now()  // createdAt
+        LocalDateTime.now()  // createdAt
     );
   }
 }

--- a/src/main/java/com/swyp10/pinggyewang/service/mock/TestClovaService.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/mock/TestClovaService.java
@@ -15,7 +15,7 @@ public class TestClovaService implements ExcuseGenerator {
   }
 
   @Override
-  public ExcuseResponse generateSentence(ExcuseRequest request) {
+  public ExcuseResponse generateSentence(final ExcuseRequest request) {
     return mockExcuseGenerator.generateMockResponse(request);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
     defer-datasource-initialization: true
 
 logging:

--- a/src/test/java/com/swyp10/pinggyewang/service/ClovaTest.java
+++ b/src/test/java/com/swyp10/pinggyewang/service/ClovaTest.java
@@ -29,8 +29,9 @@ class ClovaTest {
         final String situation = "회의에 늦음";
         final String target = "팀장님";
         final String tone = "정중하게";
+        final boolean isRegenerated = false;
 
-        ExcuseRequest request = new ExcuseRequest(situation, target, tone);
+        ExcuseRequest request = new ExcuseRequest(situation, target, tone, isRegenerated);
 
         ExcuseResponse response = excuseGenerator.generateSentence(request);
 

--- a/src/test/java/com/swyp10/pinggyewang/service/ExcuseServiceTest.java
+++ b/src/test/java/com/swyp10/pinggyewang/service/ExcuseServiceTest.java
@@ -61,7 +61,6 @@ class ExcuseServiceTest {
         .alternatives("[\"차가 고장났습니다\"]")
         .tokensUsed(100)
         .responseTimeMs(2000L)
-        .aiCreatedAt(OffsetDateTime.now())
         .build();
 
     given(excuseRepository.findAll()).willReturn(List.of(excuse));


### PR DESCRIPTION
### 미니 대시보드 데이터 조회 기능 추가, Excuse DB 테이블 컬럼 수정

git issue 기반으로 DB 수정 및 대시보드에 들어갈 데이터 목록 수정했습니다.

- [x] excuses 테이블에 is_regenerated 컬럼 추가 (TINYINT(1))
- [x] 시간대 관련 이슈 해결을 위한 타임스탬프 필드 개선
- [x] 한국 시간대(Asia/Seoul) 기반 created_at 처리

- 총 생성 건수: 전체 핑계 생성 횟수 집계
- 평균 만족도: credibility_score 기반 만족도 평균 계산
- 재생성률: 재생성된 핑계 비율 통계
- 피크 타임: 시간대별 가장 많이 생성된 시간 분석

close #25 
