### PR TITLE
feat: dockerfile, docker-compose 추가하여 가상 컨테이너에서 서버 실행되도록 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:17-jdk-slim
+
+WORKDIR /app
+
+# JAR 파일을 컨테이너로 복사
+COPY build/libs/*.jar app.jar
+
+# 포트 노출
+EXPOSE 8080
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+# Docker Compose 파일 버전
+version: '3.8'
+
+# 실행할 서비스들 정의
+services:
+  # MySQL 데이터베이스 서비스
+  mysql:
+    image: mysql:8.0                    # MySQL 8.0 공식 이미지 사용
+    container_name: mysql-container     # 컨테이너 이름을 mysql-container로 지정
+
+    # MySQL 초기 설정을 위한 환경변수들
+    environment:
+      MYSQL_ROOT_PASSWORD: "1234"
+      MYSQL_DATABASE: pinggyewang_dev
+      MYSQL_USER: pinggyewang_user
+      MYSQL_PASSWORD: pinggyewang_pass
+
+    # 포트 매핑 (호스트:컨테이너)
+    ports:
+      - "3306:3306"                     # 호스트의 3306 포트를 컨테이너의 3306 포트에 연결
+
+    # 데이터 영구 저장을 위한 볼륨 마운트
+    volumes:
+      - mysql_data:/var/lib/mysql       # mysql_data 볼륨을 MySQL 데이터 디렉토리에 마운트
+
+    # MySQL이 완전히 준비되었는지 확인하는 헬스체크
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]  # mysqladmin ping 명령으로 상태 확인
+      timeout: 20s                      # 각 체크마다 20초 타임아웃 설정
+      retries: 10                       # 최대 10번까지 재시도
+
+  # Spring Boot 애플리케이션 서비스
+  spring-app:
+    build: .                            # 현재 디렉토리의 Dockerfile을 사용해서 이미지 빌드
+    container_name: spring-app          # 컨테이너 이름을 spring-app으로 지정
+
+    # 포트 매핑
+    ports:
+      - "8080:8080"                     # 호스트의 8080 포트를 컨테이너의 8080 포트에 연결
+
+    # 서비스 시작 순서 제어
+    depends_on:
+      mysql:
+        condition: service_healthy      # MySQL이 healthy 상태가 될 때까지 기다린 후 시작
+
+    # Spring Boot 애플리케이션에 전달할 환경변수들
+    environment:
+      # host.docker.internal을 사용해서 호스트의 MySQL에 접근
+      - SPRING_DATASOURCE_URL=jdbc:mysql://host.docker.internal:3306/pinggyewang_dev?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+      - SPRING_DATASOURCE_USERNAME=root
+      - SPRING_DATASOURCE_PASSWORD=1234
+
+# 데이터 영구 저장을 위한 볼륨 정의
+volumes:
+  mysql_data: # mysql_data라는 이름의 볼륨 생성 (DB 데이터 보존용)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/pinggyewang_dev?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://host.docker.internal:3306/pinggyewang_dev?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true}
+    username: ${SPRING_DATASOURCE_USERNAME:root}
+    password: ${SPRING_DATASOURCE_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: root
-    password: 1234
 
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 기능 설명
클라우드 DB 사용시 요금 과다 문제가 발생할 것으로 확인하였고, DB를 스프링 서버와 같이 두도록 변경
같이 띄우게 되면 docker-compose를 통해 한번에 가상 컨테이너 환경에서 실행 가능
dockerfile로 스프링 이미지 빌드, docker-compose로 mysql과 스프링 동시 실행

## 구현 내용
<!-- 체크리스트 형태로 작성 -->
- [x] Dockerfile 소스 작성
- [x] docker-compose.yml 소스 작성
- [x] 로컬 환경에서 서버 구동시 정상 작동 확인

## 특이사항
1. 기존에 돌아가는 mysql은 종료해주셔야됩니다.
2. mysql 이미지를 생성하고 pinggyewang_dev라는 데이터베이스를 생성 해야합니다.

## 스크린샷
<img width="731" height="545" alt="Image" src="https://github.com/user-attachments/assets/483ffc94-b1ae-4d82-ab15-a7812dcef949" />

close #32 