### PR TITLE
feat: 핑계 생성 결과 이미지 추가, 핑계 생성 json parsing

### DIFF
--- a/src/main/java/com/swyp10/pinggyewang/controller/ClovaController.java
+++ b/src/main/java/com/swyp10/pinggyewang/controller/ClovaController.java
@@ -1,8 +1,9 @@
 package com.swyp10.pinggyewang.controller;
 
 import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
-import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
+import com.swyp10.pinggyewang.dto.response.WithImageResponse;
 import com.swyp10.pinggyewang.service.ExcuseGenerator;
+import com.swyp10.pinggyewang.service.ImageMappingService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,13 +14,22 @@ public class ClovaController {
 
   private final ExcuseGenerator excuseGenerator;
 
-  public ClovaController(ExcuseGenerator excuseGenerator) {
+  private final ImageMappingService imageMappingService;
+
+  public ClovaController(ExcuseGenerator excuseGenerator, ImageMappingService imageMappingService) {
     this.excuseGenerator = excuseGenerator;
+      this.imageMappingService = imageMappingService;
   }
 
   @PostMapping("/api/clova/generate")
-  public ResponseEntity<ExcuseResponse> textGenerate(@RequestBody ExcuseRequest request) {
-    ExcuseResponse response = excuseGenerator.generateSentence(request);
+  public ResponseEntity<WithImageResponse> textGenerate(@RequestBody ExcuseRequest request) {
+
+    WithImageResponse excuse = excuseGenerator.generateSentence(request);
+
+    String imageKey = imageMappingService.selectImageKey(request.target(), request.tone());
+
+    WithImageResponse response = new WithImageResponse(excuse.excuse(), imageKey);
+
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/swyp10/pinggyewang/domain/ImageMapping.java
+++ b/src/main/java/com/swyp10/pinggyewang/domain/ImageMapping.java
@@ -1,0 +1,55 @@
+package com.swyp10.pinggyewang.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "image_mapping", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_map", columnNames = {"situation", "tone"})
+})
+public class ImageMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String target;
+
+    @Column(nullable = false)
+    private String tone;
+
+    @Column(name = "image_key", nullable = false)
+    private String imageKey;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTone() {
+        return tone;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public String getImageKey() {
+        return imageKey;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setTone(String tone) {
+        this.tone = tone;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public void setImageKey(String imageKey) {
+        this.imageKey = imageKey;
+    }
+}

--- a/src/main/java/com/swyp10/pinggyewang/dto/response/WithImageResponse.java
+++ b/src/main/java/com/swyp10/pinggyewang/dto/response/WithImageResponse.java
@@ -1,0 +1,7 @@
+package com.swyp10.pinggyewang.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WithImageResponse(ExcuseResponse excuse, String imageKey) {
+}

--- a/src/main/java/com/swyp10/pinggyewang/repository/ImageMappingRepository.java
+++ b/src/main/java/com/swyp10/pinggyewang/repository/ImageMappingRepository.java
@@ -1,0 +1,10 @@
+package com.swyp10.pinggyewang.repository;
+
+import com.swyp10.pinggyewang.domain.ImageMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ImageMappingRepository extends JpaRepository<ImageMapping, Long> {
+    Optional<ImageMapping> findByTargetAndTone(String target, String tone);
+}

--- a/src/main/java/com/swyp10/pinggyewang/service/ClovaService.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/ClovaService.java
@@ -1,15 +1,18 @@
 package com.swyp10.pinggyewang.service;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
 import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
+import com.swyp10.pinggyewang.dto.response.WithImageResponse;
 import com.swyp10.pinggyewang.exception.ClovaException;
 import com.swyp10.pinggyewang.exception.CustomErrorCode;
 import com.swyp10.pinggyewang.repository.ExcuseRepository;
 import java.time.Duration;
 import java.util.regex.Pattern;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
@@ -45,19 +48,24 @@ public class ClovaService implements ExcuseGenerator {
     this.objectMapper = objectMapper;
     this.systemPrompt = systemPrompt;
     this.excuseRepository = excuseRepository;
+
+    objectMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+    objectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+    objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+    objectMapper.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA, true);
   }
 
   @Override
-  public ExcuseResponse generateSentence(final ExcuseRequest request) {
+  public WithImageResponse generateSentence(final ExcuseRequest request) {
     try {
       String requestBody = buildRequestBody(request);
       String apiResponse = callClovaApi(requestBody);
       String extractedContent = extractContentFromResponse(apiResponse);
-      ExcuseResponse response = parseExcuseResponse(extractedContent);
 
-      excuseRepository.save(response.toExcuse(request.isRegenerated()));
+      WithImageResponse wrapper = parseWithImageResponse(extractedContent);
+      excuseRepository.save(wrapper.excuse().toExcuse(request.isRegenerated()));
 
-      return response;
+      return wrapper;
     } catch (Exception e) {
       throw new ClovaException(CustomErrorCode.CLOVA_EXCEPTION);
     }
@@ -130,14 +138,21 @@ public class ClovaService implements ExcuseGenerator {
     }
   }
 
-  private ExcuseResponse parseExcuseResponse(String jsonContent) throws JsonProcessingException {
-    try {
-      ExcuseResponse response = objectMapper.readValue(jsonContent, ExcuseResponse.class);
-      validateResponse(response);
-      return response;
+  private WithImageResponse parseWithImageResponse(String jsonContent) {
 
-    } catch (JsonProcessingException e) {
-      throw new ClovaException(CustomErrorCode.CLOVA_JSON_PARSE_EXCEPTION);
-    }
+       try {
+
+         JsonNode root     = objectMapper.readTree(jsonContent);
+         JsonNode actual = root.isTextual() ? objectMapper.readTree(root.textValue()) : root;
+
+         ExcuseResponse excuse = objectMapper.treeToValue(actual, ExcuseResponse.class);
+
+         String imageKey = actual.path("imageKey").asText(null);
+
+         validateResponse(excuse);
+         return new WithImageResponse(excuse, imageKey);
+       } catch (JsonProcessingException e) {
+           throw new ClovaException(CustomErrorCode.CLOVA_JSON_PARSE_EXCEPTION);
+       }
   }
 }

--- a/src/main/java/com/swyp10/pinggyewang/service/ExcuseGenerator.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/ExcuseGenerator.java
@@ -2,7 +2,8 @@ package com.swyp10.pinggyewang.service;
 
 import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
 import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
+import com.swyp10.pinggyewang.dto.response.WithImageResponse;
 
 public interface ExcuseGenerator {
-  ExcuseResponse generateSentence(ExcuseRequest request);
+  WithImageResponse generateSentence(ExcuseRequest request);
 }

--- a/src/main/java/com/swyp10/pinggyewang/service/ImageMappingService.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/ImageMappingService.java
@@ -1,0 +1,20 @@
+package com.swyp10.pinggyewang.service;
+
+import com.swyp10.pinggyewang.domain.ImageMapping;
+import com.swyp10.pinggyewang.repository.ImageMappingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ImageMappingService {
+
+    private final ImageMappingRepository mappingRepo;
+
+    public String selectImageKey(String target, String tone){
+        return mappingRepo.findByTargetAndTone(target.trim(), tone.trim())
+                .map(ImageMapping::getImageKey)
+                .orElse("B") // 기본 이미지
+                ;
+    }
+}

--- a/src/main/java/com/swyp10/pinggyewang/service/mock/MockExcuseGenerator.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/mock/MockExcuseGenerator.java
@@ -5,28 +5,34 @@ import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
+
+import com.swyp10.pinggyewang.dto.response.WithImageResponse;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MockExcuseGenerator {
 
-  public ExcuseResponse generateMockResponse(ExcuseRequest request) {
-    return new ExcuseResponse(
-        "회의에 늦음",  // situation
-        request.target(),  // target (요청에서 받은 값 사용)
-        request.tone(),    // tone (요청에서 받은 값 사용)
-        "죄송합니다, " + request.target() + ". 오늘 아침 교통 상황이 예상보다 훨씬 나빠서 회의에 늦게 도착했습니다.",  // excuse
-        "교통 상황은 예측하기 어려운 경우가 많으며, 출근길 교통 체증은 많은 사람들이 겪는 문제이므로 믿을 만한 이유입니다.",  // credibilityWhy
-        8.0,  // credibilityScore
-        "시간 관리 실패",  // category
-        List.of("교통 체증", "예측 불가능"),  // keyword
-        List.of(
-            "오늘 도로 공사 때문에 지연되었습니다.",
-            "예상치 못한 차량 고장으로 인해 지각했습니다."
-        ),  // alts
-        10,  // tokensUsed
-        300L,  // responseTimeMs
-        LocalDateTime.now()  // createdAt
-    );
+  public WithImageResponse generateMockResponse(ExcuseRequest request) {
+      ExcuseResponse testData = new ExcuseResponse(
+              "회의에 늦음",  // situation
+              request.target(),  // target (요청에서 받은 값 사용)
+              request.tone(),    // tone (요청에서 받은 값 사용)
+              "죄송합니다, " + request.target() + ". 오늘 아침 교통 상황이 예상보다 훨씬 나빠서 회의에 늦게 도착했습니다.",  // excuse
+              "교통 상황은 예측하기 어려운 경우가 많으며, 출근길 교통 체증은 많은 사람들이 겪는 문제이므로 믿을 만한 이유입니다.",  // credibilityWhy
+              8.0,  // credibilityScore
+              "시간 관리 실패",  // category
+              List.of("교통 체증", "예측 불가능"),  // keyword
+              List.of(
+                      "오늘 도로 공사 때문에 지연되었습니다.",
+                      "예상치 못한 차량 고장으로 인해 지각했습니다."
+              ),  // alts
+              10,  // tokensUsed
+              300L,  // responseTimeMs
+              LocalDateTime.now()  // createdAt
+      );
+
+      String imageKey = "B";
+
+      return new WithImageResponse(testData, imageKey);
   }
 }

--- a/src/main/java/com/swyp10/pinggyewang/service/mock/TestClovaService.java
+++ b/src/main/java/com/swyp10/pinggyewang/service/mock/TestClovaService.java
@@ -2,6 +2,7 @@ package com.swyp10.pinggyewang.service.mock;
 
 import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
 import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
+import com.swyp10.pinggyewang.dto.response.WithImageResponse;
 import com.swyp10.pinggyewang.service.ExcuseGenerator;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,7 @@ public class TestClovaService implements ExcuseGenerator {
   }
 
   @Override
-  public ExcuseResponse generateSentence(final ExcuseRequest request) {
+  public WithImageResponse generateSentence(final ExcuseRequest request) {
     return mockExcuseGenerator.generateMockResponse(request);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,9 +25,13 @@ clova:
     당신은 "핑계 생성기" AI입니다.
     JSON 입력으로 "situation", "target", "tone", "isRegenerated", "regeneratedBtnVal", "questions" 키가 주어지면,  
     questions 배열의 각 항목에 담긴 prompt와 answer를 순서대로 읽어 사용자로부터 받은 답변을 모두 반영한  
-    구체적이고 설득력 있는 핑계 문장을 JSON 형태로 반환해야 합니다.
+    구체적이고 설득력 있는 핑계 문장을 마크아둔, 코드블럭, 주석, 설명없이  JSON 형태로 반환해야 합니다.
     isRegenerated가 true 인 경우 regeneratedBtnVal 직전 생성한 핑계를 수정해서 다시 반환합니다.
+    요청받은 내용에 욕설이 포함되어있을경우 exception으로 넘겨주세요.
     
+    예시 : {"situation":"~","target":"~","tone":"~","excuse":"~","credibilityWhy":"~","credibilityScore":85,"category":"~","keyword":["~"],"alts":["~"],"tokens_used":123,"response_time_ms":456,"imageKey":"B"}
+
+    스키마:
     {
       "situation": string,
       "target": string,
@@ -40,4 +44,5 @@ clova:
       "alts": [string],
       "tokens_used": number,
       "response_time_ms": number,
+      "imgaeKey": string|null
     }

--- a/src/test/java/com/swyp10/pinggyewang/service/ClovaTest.java
+++ b/src/test/java/com/swyp10/pinggyewang/service/ClovaTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swyp10.pinggyewang.dto.request.ExcuseRequest;
 import com.swyp10.pinggyewang.dto.request.QuestionRequest;
 import com.swyp10.pinggyewang.dto.response.ExcuseResponse;
+import com.swyp10.pinggyewang.dto.response.WithImageResponse;
 import com.swyp10.pinggyewang.service.mock.MockExcuseGenerator;
 import com.swyp10.pinggyewang.service.mock.TestClovaService;
 import org.junit.jupiter.api.Test;
@@ -42,13 +43,13 @@ class ClovaTest {
 
         ExcuseRequest request = new ExcuseRequest(situation, target, tone, isRegenerated, regeneratedBtnVal, questions);
 
-        ExcuseResponse response = excuseGenerator.generateSentence(request);
+        WithImageResponse response = excuseGenerator.generateSentence(request);
 
         System.out.println("====== AI 응답 ======");
         System.out.println(response);
 
         assertThat(response.excuse()).isNotNull();
-        assertThat(response.category()).isNotNull();
-        assertThat(response.createdAt()).isNotNull();
+        assertThat(response.excuse().category()).isNotNull();
+        assertThat(response.excuse().createdAt()).isNotNull();
     }
 }


### PR DESCRIPTION
핑계 생성 결과 이미지 매핑 추가

- 핑계 생성 결과 json{
    "excuse": {
        "situation": "회의에 늦음",
        "target": "상사/선배",
        "tone": "유머러스하게",
        "excuse": "오늘 아침에 출근하다가 깜짝 놀랐어요! 갑자기 제가 매일 건너는 육교가 마치 영화처럼 와르르 무너지더라고요. 비바람이 어찌나 세던지, 진짜 재난 영화의 주인공인 줄 알았어요! 다행히 다치지는 않았지만, 덕분에 조금 늦게 도착하게 됐네요. 애교 섞어서 이해 부탁드려도 될까요?",
        "credibilityWhy": "육교 붕괴라는 유머러스하지만 과장된 상황을 통해 상사의 이해를 구하는 전략.",
        "credibilityScore": 75.0,
        "category": "자연재해",
        "keyword": [
            "육교",
            "무너짐",
            "비바람"
        ],
        "alts": [
            "고장난 지하철로 인해 지각",
            "교통 체증 때문에 지각"
        ],
        "tokens_used": 111,
        "response_time_ms": 300,
        "created_at": null
    },
    "imageKey": "E"
}

- image_mapping 테이블 추가
- 프롬프트 imageKey 항목 추가